### PR TITLE
the image of version 2.0 is not avaiable, change it to 6.0

### DIFF
--- a/manifests/deployment.yaml
+++ b/manifests/deployment.yaml
@@ -25,7 +25,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: ppl521/paddle-operator:2.0
+        image: ppl521/paddle-operator:6.0
         name: paddle-operator
         volumeMounts:
         - mountPath: /etc/config


### PR DESCRIPTION
If we use the image of version 2.0, it will cause the error as follow:
```
Events:
  Type     Reason     Age                From                 Message
  ----     ------     ----               ----                 -------
  Normal   Scheduled  15s                default-scheduler    Successfully assigned default/paddle-operator-6f74bfb47-6wmbx to 10.13.33.7
  Normal   Pulled     14s (x2 over 15s)  kubelet, 10.13.33.7  Container image "ppl521/paddle-operator:2.0" already present on machine
  Normal   Created    14s (x2 over 15s)  kubelet, 10.13.33.7  Created container
  Warning  Failed     13s (x2 over 14s)  kubelet, 10.13.33.7  Error: failed to start container "paddle-operator": Error response from daemon: OCI runtime create failed: container_linux.go:344: starting container process caused "exec: \"paddlejob\": executable file not found in $PATH": unknown
  Warning  BackOff    5s                 kubelet, 10.13.33.7  Back-off restarting failed container
```

Change the  `deployment.yaml`.